### PR TITLE
Se elimina file xml_sign_temp solo si existe, repara error Object.unlinkSync

### DIFF
--- a/src/XMLDsig.ts
+++ b/src/XMLDsig.ts
@@ -129,8 +129,10 @@ class XMLDsig {
             }
 
             try {
-              fs.unlinkSync(tmpXMLToSign);
-              //file removed
+             if (tmpXMLToSign) {
+                  //file removed, if exists
+                fs.unlinkSync(tmpXMLToSign);
+             }
             } catch (err) {
               console.error(err);
             }


### PR DESCRIPTION
para evitar el error   Error: ENOENT: no such file or directory, unlink '~/node_modules/facturacionelectronicapy-xmlsign/dist/xml_sign_temp_242671.xml'
0|fe  |     at Object.unlinkSync (fs.js:1255:3)
0|fe  |   ~node_modules/facturacionelectronicapy-xmlsign/dist/XMLDsig.js:123:32
0|fe  |     at ChildProcess.exithandler (child_process.js:390:5)
0|fe  |     at ChildProcess.emit (events.js:400:28)
0|fe  |     at maybeClose (internal/child_process.js:1058:16)
0|fe  |     at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5) {
0|fe  |   errno: -2,
0|fe  |   syscall: 'unlink',
0|fe  |   code: 'ENOENT',
0|fe  |   path: '~/node_modules/facturacionelectronicapy-xmlsign/dist/xml_sign_temp_242671.xml'
0|fe  | }